### PR TITLE
Fix schedule comment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: generate animation
 
 on:
-  # run automatically every 24 hours
+  # run automatically every 12 hours
   schedule:
-    - cron: "0 */12 * * *" 
+    - cron: "0 */12 * * *"
   
   # allows to manually run the job at any time
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- correct the schedule comment to match a 12-hour cron job

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a529f0de48328af2ec8697504badf